### PR TITLE
bugfix: raycasting was ignoring walls closer than `min_range`

### DIFF
--- a/racecar_gym/bullet/sensors.py
+++ b/racecar_gym/bullet/sensors.py
@@ -83,8 +83,10 @@ class Lidar(BulletSensor[NDArray[(Any,), np.float]]):
                                                    rays=self._rays)
 
     def _setup_raycast(self, min_distance: float, scan_range: float, rays: int):
-        start = min_distance
-        end = min_distance + scan_range
+        # bugfix: the raycast must start from the car,
+        # otherwise it will ignore walls that closer than  ̀mindist`from the sensor
+        start = 0.0
+        end = scan_range
         from_points, to_points = [], []
         angle = self._config.angle_start + np.pi / 2.0
         increment = self._config.angle / self._config.rays

--- a/racecar_gym/bullet/sensors.py
+++ b/racecar_gym/bullet/sensors.py
@@ -78,11 +78,10 @@ class Lidar(BulletSensor[NDArray[(Any,), np.float]]):
         self._miss_color = [0, 1, 0]
         self._ray_ids = []
 
-        self._from, self._to = self._setup_raycast(min_distance=self._min_range,
-                                                   scan_range=self._range,
+        self._from, self._to = self._setup_raycast(scan_range=self._range,
                                                    rays=self._rays)
 
-    def _setup_raycast(self, min_distance: float, scan_range: float, rays: int):
+    def _setup_raycast(self, scan_range: float, rays: int):
         # bugfix: the raycast must start from the car,
         # otherwise it will ignore walls that closer than  ̀mindist`from the sensor
         start = 0.0


### PR DESCRIPTION
Fix issue of lidar rays propagated beyond the walls. 

**Problem**: the raycasting is computed starting from a point at distance `min_distance` in the sensor coordinate system. 
When the car collides with a wall, the distance between the sensor and the wall is lower than `min_distance` but the ray was erroneously propagated from a point at `min_distance`, which is beyond the wall.

**Solution**: the raycasting starts at distance 0. The `min_distance` of the sensor reading is simply applied after the raycasting, through a clipping operation.
