### PR TITLE
update readme and refactoring world

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ agents:
     vehicle:
       name: racecar
       sensors: [lidar, pose, velocity, acceleration]
+      actuators: [motor, steering]
       color: blue # default is blue, one of red, green, blue, yellow, magenta or random
     task:
       task_name: maximize_progress
@@ -74,15 +75,21 @@ pose, velocity, acceleration, LiDAR and RGB Camera. Further, the observation spa
 |rgb_camera|`Box(<height>, <width>, 3)`|`height: 240, width: 320`|RGB image of the front camera.|
 
 ### Actions
-The action space for a single agent is a defined by the actuators of the vehicle. For instance, [differential racecar](models/vehicles/racecar/racecar.yml)
-defines two actuators: motor and steering. The action space is therefore a dictionary with keys `motor` and `steering`.
-Note, that the action space of the car is normalized between -1 and 1.
-The complete action space for this vehicle looks like this:
+The action space for a single agent is a defined by the actuators of the vehicle. 
+**By default**, [differential racecar](models/vehicles/racecar/racecar.yml) defines two actuators: motor and steering. 
+The action space is therefore a dictionary with keys `motor` and `steering`.
 
-|Key|Space|Description|
-|---|---|---|
-|motor|`Box(low=-1, high=1, shape=(1,))`|Throttle command. If negative, the car accelerates backwards.|
-|steering|`Box(low=-1, high=1, shape=(1,))`|Normalized steering angle.|
+Alternatevely, the agent can control the target speed and steering, but must be defined in the scenario specification.
+In this case, the action space is a dictionary with keys `speed` and `steering`.
+
+Note, that the action space of the car is normalized between -1 and 1.
+The action space can include the following actuators:
+
+| Key      |Space| Description                                                                 |
+|----------|---|-----------------------------------------------------------------------------|
+| motor    |`Box(low=-1, high=1, shape=(1,))`| Throttle command. If negative, the car accelerates backwards.               |
+| speed    |`Box(low=-1, high=1, shape=(1,))`| Normalized target speed. |
+| steering |`Box(low=-1, high=1, shape=(1,))`| Normalized steering angle.                                                  |
 
 ### State
 In addition to observations obtained by sensors, the environment passes back the true state of each vehicle in each

--- a/racecar_gym/bullet/world.py
+++ b/racecar_gym/bullet/world.py
@@ -51,13 +51,12 @@ class World(world.World):
                 ('progress', 'norm_distance_from_start'),
                 ('obstacle', 'norm_distance_to_obstacle'),
                 ('occupancy', 'drivable_area')
-                ]
+            ]
         ])
         self._state['maps'] = self._maps
         self._tmp_occupancy_map = None      # used for `random_ball` sampling
         self._progress_center = None        # used for `random_ball` sampling
         self._trajectory = []
-
 
     def init(self) -> None:
         if self._config.rendering:
@@ -167,20 +166,6 @@ class World(world.World):
         pose = self._state[agent.id]['pose']
         progress = progress_map.get_value(position=(pose[0], pose[1], 0))
         dist_obstacle = obstacle_map.get_value(position=(pose[0], pose[1], 0))
-
-        # compute next waypoint
-        margin = 50
-        y, x = progress_map.to_pixel((pose[0], pose[1], 0.0))
-        progress_surround = progress_map._map[y-margin:y+margin, x-margin:x+margin]
-        # note: we have to discard too far progresses because they could be part of future sections of the map
-        # they are visible in the surrounding of the progress map, but not reachable by the current position
-        reasonable_surround = progress_surround * (progress_surround <= (progress + 0.05))
-        mask_best_progress = reasonable_surround >= np.max(reasonable_surround)
-        masked_distance_surround = obstacle_map._map[y-margin:y+margin, x-margin:x+margin] * mask_best_progress
-        rel_row, rel_col = np.unravel_index(np.argmax(masked_distance_surround), masked_distance_surround.shape)
-        waypoint = progress_map.to_meter(y-margin+rel_row, x-margin+rel_col)
-
-        self._state[agent.id]['next_waypoint'] = (*waypoint, 0.0)
 
         self._state[agent.id]['velocity'] = velocity
         self._state[agent.id]['progress'] = progress


### PR DESCRIPTION
1. Updated readme with new action space.
2.  Removed the computation of a progress-based waypoint because was unused and raised errors in small tracks.
- *Error:* the computation did not explicitly manage the progress margin and caused out-of-bounds indices when accessing the progress map.
- *Solution*: since the next_waypoint was actually never used (it was a leftover of previous experiments), removing the computation is the best option.